### PR TITLE
Set a trial end_date in the future to reveal it being canceled

### DIFF
--- a/trials.json
+++ b/trials.json
@@ -23,7 +23,7 @@
     "name": "Carboplatin +/- Nivolumab in Metastatic Triple Negative Breast Cancer",
     "country": "ES",
     "start_date": "2018-06-13",
-    "end_date": "2023-07-17",
+    "end_date": "2025-07-17",
     "sponsor": "Sanofi",
     "canceled": true,
     "study_type": "interventional",


### PR DESCRIPTION
Without this change, the trial was not on-ongoing even if it was not canceled